### PR TITLE
Use inherits to test for "gbm" class

### DIFF
--- a/R/reconstructGBMdata.R
+++ b/R/reconstructGBMdata.R
@@ -13,7 +13,7 @@
 #' @export
 reconstructGBMdata <- function(x)
 {
-   if(class(x) != "gbm")
+   if(!inherits(x, "gbm"))
    {
       stop( "This function is for use only with objects having class 'gbm'" )
    } else


### PR DESCRIPTION
This is a change to allow prediction with objects that inherit from the "gbm" class; e.g., an object ``x`` for which ``class(x) <- c("gbm_extension", "gbm")``.  The ``reconstructGBMdata`` function being modified is called by ``predict.gbm`` and will terminate with an error if the class is not a single "gbm" value as originally implemented.  That requirement is more restrictive than necessary, since inherited objects should have all of the gbm list elements needed to perform prediction.

Thanks.